### PR TITLE
[cmake] require boost regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.13)
 project(streamblocks-sdf3)
 
+
+# Put executable targets under /bin
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(base)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ cmake ..
 make
 ```
 
+The executables are listed under the `build/bin/` folder.
 ------------------------------------------------------------------
 
 ### Which software dependencies does SDF3 have?

--- a/sdf/CMakeLists.txt
+++ b/sdf/CMakeLists.txt
@@ -1,4 +1,9 @@
+
+# sdf3 requires libxml2
 find_package(LibXml2 REQUIRED)
+
+# sdf3 requires libboost-regex-dev
+find_package( Boost REQUIRED COMPONENTS regex)
 
 if(WIN32)
     add_definitions(-D_ITERATION_DEBUG_LEVEL=0)


### PR DESCRIPTION
Changelog:

* Require boost regex.
* Put executables under `build/bin` folder.

## Details

See boost related line.

```
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found LibXml2: /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libxml2.tbd (found version "2.9.4") 
-- Found Boost: /opt/homebrew/lib/cmake/Boost-1.78.0/BoostConfig.cmake (found version "1.78.0") found components: regex 
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/zouzias/huawei-repos/streamblocks-sdf3/build

```